### PR TITLE
Fixed: limit access admin page when not login admin user

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    libv8 (3.16.14.7)
+    libv8 (3.16.14.19)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -296,3 +296,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.15.3

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -23,6 +23,4 @@
   </div>
 <% end %>
 
-= link_to "Sign in with Facebook", user_omniauth_authorize_path(:facebook)
-
 <%= render "devise/shared/links" %>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -3,10 +3,10 @@ RailsAdmin.config do |config|
   ### Popular gems integration
 
   ## == Devise ==
-  # config.authenticate_with do
-  #   warden.authenticate! scope: :user
-  # end
-  # config.current_user_method(&:current_user)
+  config.authenticate_with do
+    warden.authenticate! scope: :admin_user
+  end
+  config.current_user_method(&:current_admin_user)
 
   ## == Cancan ==
   # config.authorize_with :cancan

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   devise_for :models
-  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   devise_for :admin_users
+  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   resources :events
   resources :titles
   resources :viewing_logs


### PR DESCRIPTION
# 目的

AdminUserがあるが、ログインされなくてもAdminページにアクセスできるため、
ログインを必要とさせる。

# 注意点

bundleでエラーになっていたので、解消したがこれでいいのか不明だが、
libv8をUpdateするとできた。(El Capitanはこれでいいと思う)
https://qiita.com/ganta/items/53f616b48e94d989952f#libv8をアップデートする-推奨

```
bundle update libv8
```